### PR TITLE
pre-requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ** Open EE Meter Fork ***
+
+The fork allows installs numpy before installing pip requirements in order to be able to install the `statsmodels`, which fails without an existing numpy install. The numpy install is triggered by a file `pre-requirements.txt`. This file has the same format as a pip requirements file. 
+
+An IFTTT recipe is set up to alert us when the upstream repo has changes for merging.
+
 ![python](https://cloud.githubusercontent.com/assets/51578/13712821/b68a42ce-e793-11e5-96b0-d8eb978137ba.png)
 
 # Heroku Buildpack: Python

--- a/bin/compile
+++ b/bin/compile
@@ -190,9 +190,11 @@ sub-env $BIN_DIR/steps/geo-libs
 # GDAL support.
 source $BIN_DIR/steps/gdal
 
-# HACK: makes sure numpy is in place before installing other dependencies
-# Maybe make this triggered by a .numpy file in the repo? (similar to python-runtime.txt)
-pip install numpy==1.10.2
+# HACK: allow installing requirements that need to be in place before installing
+# pip requirements.
+if [ -f pre-requirements.txt ]; then
+  source $BIN_DIR/steps/pre-pip-install
+fi
 
 # Install dependencies with Pip (where the magic happens).
 source $BIN_DIR/steps/pip-install

--- a/bin/steps/pre-pip-install
+++ b/bin/steps/pre-pip-install
@@ -1,0 +1,12 @@
+puts-cmd "pip install -r pre-requirements.txt"
+
+set +e
+/app/.heroku/python/bin/pip install -r $BUILD_DIR/pre-requirements.txt --exists-action=w --src=/app/.heroku/src --disable-pip-version-check --no-cache-dir 2>&1 | tee $WARNINGS_LOG | cleanup | indent
+PIP_STATUS="${PIPESTATUS[0]}"
+set -e
+
+show-warnings
+
+if [[ ! $PIP_STATUS -eq 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
The fork allows installs numpy before installing pip requirements in order to be able to install the `statsmodels`, which fails without an existing numpy install. The numpy install is triggered by a file `pre-requirements.txt`. This file has the same format as a pip requirements file. 