### PR TITLE
pipenv --deploy (#476)

### DIFF
--- a/bin/steps/pipenv
+++ b/bin/steps/pipenv
@@ -14,7 +14,7 @@ if [[ -f Pipfile ]]; then
         if [[ ! -f Pipfile.lock ]]; then
             /app/.heroku/python/bin/pipenv install --system --skip-lock 2>&1 | indent
         else
-            /app/.heroku/python/bin/pipenv install --system 2>&1 | indent
+            /app/.heroku/python/bin/pipenv install --system --deploy 2>&1 | indent
         fi
         # Install the dependencies.
 

--- a/test/fixtures/pipenv-full-version/Pipfile.lock
+++ b/test/fixtures/pipenv-full-version/Pipfile.lock
@@ -1,23 +1,68 @@
 {
-    "default": {
-        "requests": {
-            "version": "==2.13.0",
-            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb"
-        }
-    },
-    "develop": {},
     "_meta": {
+        "hash": {
+            "sha256": "8f9e3d5a2863652d7495f17427a33383b3bd9ebd55d331be41fee3cf8631bcd3"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.2",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "17.0.0",
+            "platform_system": "Darwin",
+            "platform_version": "Darwin Kernel Version 17.0.0: Thu Aug 24 21:48:19 PDT 2017; root:xnu-4570.1.46~2/RELEASE_X86_64",
+            "python_full_version": "3.6.2",
+            "python_version": "3.6",
+            "sys_platform": "darwin"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_full_version": "3.6.2"
+        },
         "sources": [
             {
                 "url": "https://pypi.python.org/simple",
                 "verify_ssl": true
             }
-        ],
-        "requires": {
-            "python_version": "3.6"
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:54a07c09c586b0e4c619f02a5e94e36619da8e2b053e20f594348c0611803704",
+                "sha256:40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+            ],
+            "version": "==2017.7.27.1"
         },
-        "hash": {
-            "sha256": "5866990104fc8f27d13cdf01abc2a32c553129e03f666316cacc5b42d3e0884e"
+        "chardet": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+            ],
+            "version": "==2.6"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
+                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+            ],
+            "version": "==2.18.4"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
         }
-    }
+    },
+    "develop": {}
 }


### PR DESCRIPTION
* fixed the bug for pypy-5.8.0

* changelog

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* python 2.7.14

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* pipfile > requirements.txt

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* check for python_full_version too

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* 2.7.14

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* warn when using an older version of python

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* requirements for anaconda buildpack

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* remove hashes for conda buildpack

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* improvements to pipenv python version detection

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* oops

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* oops

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* oops

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* echo not puts

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* try this

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* learn more

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* there we go

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* cleanups

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* cleanups

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* cleanups

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* unsupported

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* consistiency

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* be more specific

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* capitalize Pipfile.lock

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* attempt to force color

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* try this

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* try this

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* interactive

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* interactive

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* diagnose

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* try without -l

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* confirmed env working

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* just -c

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* use latest, to debug

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* no more bash

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* try …

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* don't use the git version of pipenv

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* oops

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* next version

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* 2.7.14

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* comment out force color bits

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* readme

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* more tests

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* more tests

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* ellipsis

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* pipenv --deploy

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>

* full version lockfile

Signed-off-by: Kenneth Reitz <me@kennethreitz.org>