### PR TITLE
Prevent Hatchet on forked PRs [changelog skip] (#966)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     sudo: false
     script: make check
   - stage: Hatchet Integration
-    if: branch = master
+    if: env(TRAVIS_PULL_REQUEST_SLUG) = env(TRAVIS_REPO_SLUG)
     name: Run Hatchet
     script:
       - bundle exec hatchet ci:setup

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,16 +15,6 @@ RSpec.configure do |config|
   end
 end
 
-if ENV['TRAVIS']
-  # Don't execute tests against "merge" commits
-  if ENV['TRAVIS_PULL_REQUEST'] != 'false' &&
-      ENV['TRAVIS_BRANCH'] == 'master' &&
-      ENV["TRAVIS_PULL_REQUEST_SLUG"] != ENV['TRAVIS_REPO_SLUG'] # forked PR
-    puts "Skipping Hatchet tests"
-    exit 0
-  end
-end
-
 DEFAULT_STACK = 'heroku-18'
 
 def run!(cmd)


### PR DESCRIPTION
* Update travis conditional for hatchet to check for HEROKU_API_ env vars
[changelog skip]

* remove check to skip hatchet in travis in favor of better travis config

<!-- Hi and welcome to the Heroku Python buildpack repository!

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->
