### PR TITLE
[changelog skip] Fix PR edit check (#974)

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,6 +1,8 @@
 name: Check Changelog
 
-on: [pull_request]
+on:
+ pull_request:
+  types: [opened, reopened, edited, synchronize]
 
 jobs:
  build:


### PR DESCRIPTION
Previously when a PR title was edited, the "check for changelog" script would not fire. This means if someone edited it to add a "[changelog skip]" that the check would still show to be failing. This PR adds additional triggers for the check so that when the PR is edited, the check will re-run.

<!-- Hi and welcome to the Heroku Python buildpack repository!

If you meant to open a PR against a fork instead of upstream, please adjust the base branch:
https://help.github.com/articles/changing-the-base-branch-of-a-pull-request/

Otherwise thank you in advance for your Pull Request - just remember to
include as much information as possible to help the reviewers :-)
-->
